### PR TITLE
[HR_131,150] Make the pages have only one and descriptive h1 tag

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -76,6 +76,7 @@ html#{$cadmin-selector} {
 		.control-menu-level-1-heading {
 			font-size: 16px;
 			font-weight: 600;
+			margin: 0px;
 		}
 
 		.control-menu-level-1-dark {

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_header.jsp
@@ -21,5 +21,5 @@ String portletTitle = (String)request.getAttribute(ProductNavigationControlMenuW
 %>
 
 <li class="control-menu-nav-item control-menu-nav-item-content">
-	<span class="control-menu-level-1-heading text-truncate" data-qa-id="headerTitle"><%= HtmlUtil.escape(portletTitle) %></span>
+	<h1 class="control-menu-level-1-heading text-truncate" data-qa-id="headerTitle"><%= HtmlUtil.escape(portletTitle) %></h1>
 </li>

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
@@ -52,7 +52,7 @@ for (ProductNavigationControlMenuCategory productNavigationControlMenuCategory :
 
 		<div class="control-menu control-menu-level-1 control-menu-level-1-<%= applicationsMenuApp ? "light" : "dark" %> d-print-none" data-qa-id="controlMenu" id="<portlet:namespace />ControlMenu">
 			<clay:container-fluid>
-				<h1 class="sr-only"><liferay-ui:message key="admin-header" /></h1>
+				<h2 class="sr-only"><liferay-ui:message key="admin-header" /></h2>
 
 				<ul class="control-menu-level-1-nav control-menu-nav" data-namespace="<portlet:namespace />" data-qa-id="header" id="<portlet:namespace />controlMenu">
 

--- a/portal-web/docroot/html/taglib/ui/quick_access/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/quick_access/page.jsp
@@ -23,7 +23,7 @@ String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 
 <c:if test="<%= ((quickAccessEntries != null) && !quickAccessEntries.isEmpty()) || Validator.isNotNull(contentId) %>">
 	<nav aria-label="<liferay-ui:message key="quick-links" />" class="bg-dark cadmin d-none d-xl-block quick-access-nav text-center text-white" id="<%= randomNamespace %>quickAccessNav">
-		<h1 class="sr-only"><liferay-ui:message key="navigation" /></h1>
+		<h2 class="sr-only"><liferay-ui:message key="navigation" /></h2>
 
 		<ul class="list-unstyled mb-0">
 			<c:if test="<%= Validator.isNotNull(contentId) %>">


### PR DESCRIPTION
**Related Issue**: _LPS to be created_

**Related HRs**:

- HR_131 (fixes totally) :white_check_mark: 
- HR_150 (fixes totally) :white_check_mark:
- HR_105 (fixes partially, the additional fix is _here_) :warning:
- HR_168 (fixes partially, the additional fix is _[here](https://github.com/rebsilva/liferay-portal/pull/126)_) :warning:

**The solution**: Make the title in the header of each page of the portal to become an `<h1>` instead of a `<span>`, and transform the `admin-header` and `navigation` sr-only elements into `<h2>` tags instead of `<h1>`.

**Warning**: Since we are changing tags that are reflected in the whole portal, this is potentially a breaking change.

